### PR TITLE
Add multi-apply and brush for presets

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "VjLooper",
     "author": "Tu Nombre",
-    "version": (1, 2, 0),
+    "version": (1, 3, 0),
     "blender": (3, 0, 0),
     "location": "View3D > Sidebar > VjLooper",
     "description": "Animación procedural avanzada con presets, bake, preview y hot-reload",


### PR DESCRIPTION
## Summary
- add support for applying presets to multiple objects with an offset
- add a preset brush mode to quickly apply a preset when selecting objects
- allow per-object amplitude, frequency and duration scale
- expose new mirror option and global settings in panel
- bump version to 1.3.0

## Testing
- `python -m py_compile __init__.py panel.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685778a89e2c832eb1c95d4febb68519