### PR TITLE
Add signal randomization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ VjLooper es un addon para Blender que permite generar animaciones procedurales m
 - Configurar tipo de señal, amplitud, frecuencia y otros parámetros.
 - Opcionalmente guardar y cargar presets de señales.
 
+## Aleatorizar señales
+Cada animación tiene campos para "Amp Min", "Amp Max", "Freq Min" y "Freq Max".
+Establece estos rangos y pulsa **Randomize** para asignar valores aleatorios de
+amplitud y frecuencia dentro de ellos.
+


### PR DESCRIPTION
## Summary
- extend `SignalItem` with amplitude/frequency range properties
- implement `VJLOOPER_OT_randomize_signal` for assigning random values
- expose new range controls and operator in the panel UI
- document how to use signal randomization

## Testing
- `python -m py_compile panel.py __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6857827b17ac832ebdbfa93b0561944a