### PR TITLE
Add preset categories UI

### DIFF
--- a/example_presets.json
+++ b/example_presets.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "Slide In Left",
+    "category": "General",
     "data": [
       {
         "enabled": true,
@@ -25,6 +26,7 @@
   },
   {
     "name": "Push Object",
+    "category": "General",
     "data": [
       {
         "enabled": true,
@@ -49,6 +51,7 @@
   },
   {
     "name": "Bounce In",
+    "category": "General",
     "data": [
       {
         "enabled": true,
@@ -73,6 +76,7 @@
   },
   {
     "name": "Overshoot",
+    "category": "General",
     "data": [
       {
         "enabled": true,
@@ -97,6 +101,7 @@
   },
   {
     "name": "Parallax Entrance",
+    "category": "General",
     "data": [
       {
         "enabled": true,
@@ -121,6 +126,7 @@
   },
   {
     "name": "Staggered Move",
+    "category": "General",
     "data": [
       {
         "enabled": true,
@@ -145,6 +151,7 @@
   },
   {
     "name": "Z-Axis Fly In",
+    "category": "General",
     "data": [
       {
         "enabled": true,
@@ -169,6 +176,7 @@
   },
   {
     "name": "Jitter",
+    "category": "General",
     "data": [
       {
         "enabled": true,


### PR DESCRIPTION
## Summary
- include category data in example presets
- support category field in SignalPreset and preset storage
- group preset list by category with filter and rename tools
- add collapsible sections in main panel

## Testing
- `python -m py_compile panel.py`

------
https://chatgpt.com/codex/tasks/task_e_685783381434832e846895b3da2a4673