### PR TITLE
Unify English text and add translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
 # VjLooper
 
-VjLooper es un addon para Blender que permite generar animaciones procedurales mediante señales configurables y presets.
+VjLooper is a Blender add-on that generates procedural animations using configurable signals and presets.
 
-## Instalación
-1. Copiar la carpeta del addon en el directorio de addons de Blender (`scripts/addons`).
-2. Activar "VjLooper" desde las preferencias de Blender.
+## Installation
+1. Copy the add-on folder into Blender's add-ons directory (`scripts/addons`).
+2. Enable "VjLooper" from Blender's preferences.
 
-## Uso básico
-- Seleccionar un objeto y crear señales desde el panel "VjLooper" en la barra lateral.
-- Configurar tipo de señal, amplitud, frecuencia y otros parámetros.
-- Opcionalmente guardar y cargar presets de señales.
+## Basic Usage
+- Select an object and create signals from the "VjLooper" panel in the sidebar.
+- Configure signal type, amplitude, frequency and other parameters.
+- Optionally save and load signal presets.
 
-## Aleatorizar señales
-Cada animación tiene campos para "Amp Min", "Amp Max", "Freq Min" y "Freq Max".
-Establece estos rangos y pulsa **Randomize** para asignar valores aleatorios de
-amplitud y frecuencia dentro de ellos.
-
+## Randomize Signals
+Each animation has fields "Amp Min", "Amp Max", "Freq Min" and "Freq Max".
+Set these ranges and press **Randomize** to assign random amplitude and frequency values within them.

--- a/__init__.py
+++ b/__init__.py
@@ -1,17 +1,55 @@
+"""Addon entry point for VjLooper."""
+
 bl_info = {
     "name": "VjLooper",
     "author": "Matias Delera",
     "version": (1, 3, 0),
     "blender": (3, 0, 0),
     "location": "View3D > Sidebar > VjLooper",
-    "description": "Animación procedural avanzada con presets, bake, preview y hot-reload",
+    "description": (
+        "Advanced procedural animation with presets, bake, preview and hot-"
+        "reload"
+    ),
     "category": "Animation",
+}
+
+import bpy
+
+translation_dict = {
+    "es_ES": {
+        ("*", "Reload Addon"): "Recargar Addon",
+        (
+            "*",
+            "Reload VjLooper without restarting Blender",
+        ): "Recarga VjLooper sin reiniciar Blender",
+        ("*", "VjLooper reloaded"): "VjLooper recargado",
+        ("*", "Invalid preset"): "Preset invalido",
+        ("*", "Create Animation"): "Crear animacion",
+        ("*", "Global Scales"): "Escalas globales",
+        ("*", "Animations"): "Animaciones",
+        (
+            "*",
+            "Advanced procedural animation with presets, bake, preview and hot-"
+            "reload",
+        ): "Animación procedural avanzada con presets, bake, preview y hot-reload",
+        ("*", "Position X"): "Posicion X",
+        ("*", "Position Y"): "Posicion Y",
+        ("*", "Position Z"): "Posicion Z",
+        ("*", "Rotation X"): "Rotacion X",
+        ("*", "Rotation Y"): "Rotacion Y",
+        ("*", "Rotation Z"): "Rotacion Z",
+        ("*", "Scale X"): "Escala X",
+        ("*", "Scale Y"): "Escala Y",
+        ("*", "Scale Z"): "Escala Z",
+        ("*", "Uniform Scale"): "Escala Uniforme",
+    }
 }
 
 from . import signals, operators, ui
 
 
 def register():
+    bpy.app.translations.register(__package__, translation_dict)
     signals.register()
     operators.register()
     ui.register()
@@ -21,6 +59,7 @@ def unregister():
     ui.unregister()
     operators.unregister()
     signals.unregister()
+    bpy.app.translations.unregister(__package__)
 
 
 if __name__ == "__main__":

--- a/operators.py
+++ b/operators.py
@@ -1,7 +1,10 @@
+"""Blender operator implementations for the VjLooper add-on."""
+
 import bpy
 import importlib
 import json
 import random
+import sys
 from mathutils import Vector
 from bpy.props import (
     BoolProperty,
@@ -18,10 +21,10 @@ from . import signals
 
 
 class VJLOOPER_OT_hot_reload(Operator):
-    """Reload the add-on modules."""
+    """Reload all VjLooper modules."""
     bl_idname = "vjlooper.hot_reload"
     bl_label = "Reload Addon"
-    bl_description = "Recarga VjLooper sin reiniciar Blender"
+    bl_description = "Reload VjLooper without restarting Blender"
 
     def execute(self, context):
         addon = sys.modules.get(__package__)
@@ -34,7 +37,7 @@ class VJLOOPER_OT_hot_reload(Operator):
             importlib.reload(addon)
             if hasattr(addon, 'register'):
                 addon.register()
-        self.report({'INFO'}, "VjLooper recargado")
+        self.report({'INFO'}, "VjLooper reloaded")
         return {'FINISHED'}
 
 
@@ -149,7 +152,7 @@ class VJLOOPER_OT_load_preset(Operator):
         idx = sc.signal_preset_index
         pr = sc.signal_presets[idx]
         if not signals.validate_preset(pr.data):
-            self.report({'ERROR'}, "Preset invalido")
+            self.report({'ERROR'}, "Invalid preset")
             return {'CANCELLED'}
         arr = json.loads(pr.data)
         signals.apply_preset_to_object(ctx.object, arr, sc.frame_current, sc.preset_mirror)
@@ -178,7 +181,7 @@ class VJLOOPER_OT_apply_preset_multi(Operator):
             return {'CANCELLED'}
         pr = sc.signal_presets[idx]
         if not signals.validate_preset(pr.data):
-            self.report({'ERROR'}, "Preset invalido")
+            self.report({'ERROR'}, "Invalid preset")
             return {'CANCELLED'}
         arr = json.loads(pr.data)
         offset = sc.multi_offset_frames

--- a/panel.py
+++ b/panel.py
@@ -1,3 +1,5 @@
+"""Aggregates registration of VjLooper modules."""
+
 from . import signals, operators, ui
 from .signals import *
 from .operators import *

--- a/signals.py
+++ b/signals.py
@@ -1,3 +1,5 @@
+"""Core signal evaluation helpers for VjLooper."""
+
 import bpy
 import json
 import math
@@ -31,16 +33,16 @@ CHANNEL_BAKE = [
 ]
 
 CHANNEL_ITEMS = [
-    ('LOC_X', "Posicion X", ""),
-    ('LOC_Y', "Posicion Y", ""),
-    ('LOC_Z', "Posicion Z", ""),
-    ('ROT_X', "Rotacion X", ""),
-    ('ROT_Y', "Rotacion Y", ""),
-    ('ROT_Z', "Rotacion Z", ""),
-    ('SCL_X', "Escala X",   ""),
-    ('SCL_Y', "Escala Y",   ""),
-    ('SCL_Z', "Escala Z",   ""),
-    ('SCL_ALL', "Escala Uniforme", ""),
+    ('LOC_X', "Position X", ""),
+    ('LOC_Y', "Position Y", ""),
+    ('LOC_Z', "Position Z", ""),
+    ('ROT_X', "Rotation X", ""),
+    ('ROT_Y', "Rotation Y", ""),
+    ('ROT_Z', "Rotation Z", ""),
+    ('SCL_X', "Scale X",   ""),
+    ('SCL_Y', "Scale Y",   ""),
+    ('SCL_Z', "Scale Z",   ""),
+    ('SCL_ALL', "Uniform Scale", ""),
 ]
 
 brush_last_obj = None

--- a/ui.py
+++ b/ui.py
@@ -1,3 +1,5 @@
+"""User interface for the VjLooper add-on."""
+
 import bpy
 import os
 from bpy.props import (
@@ -188,7 +190,7 @@ class VJLOOPER_PT_panel(Panel):
         col.use_property_split = True
 
         box = col.box()
-        box.label(text="Crear animacion")
+        box.label(text="Create Animation")
         box.prop(sc, "signal_new_channel", text="Channel", expand=True)
         box.template_icon_view(sc, "signal_new_type", show_labels=True, scale=5.0)
         row = box.row()
@@ -202,7 +204,7 @@ class VJLOOPER_PT_panel(Panel):
         box.operator("vjlooper.add_signal", text="Add Animation")
 
         boxg = col.box()
-        boxg.label(text="Escalas globales")
+        boxg.label(text="Global Scales")
         boxg.prop(obj, "global_amp_scale", text="Amplitude Scale")
         boxg.prop(obj, "global_freq_scale", text="Frequency Scale")
         boxg.prop(obj, "global_dur_scale", text="Duration Scale")
@@ -213,7 +215,7 @@ class VJLOOPER_PT_panel(Panel):
             col = L.column()
             col.use_property_split = True
             box2 = col.box()
-            box2.label(text="Animaciones")
+            box2.label(text="Animations")
             for i, it in enumerate(obj.signal_items):
                 sub = box2.box()
                 sub.alert = not it.enabled


### PR DESCRIPTION
## Summary
- translate README to English
- add Spanish translation dictionary and register it
- add module docstrings
- update UI labels and messages to English

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68578fefb7a4832eb361a4367b93c8e6