### PR TITLE
Fix addon registration for empty scenes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -64,11 +64,18 @@ def register():
     signals.register()
     operators.register()
     tunnelfx.register()
+    ui.register_props()
+    # ensure collections exist before UI classes are registered
+    if not bpy.context.scene.signal_presets:
+        p = bpy.context.scene.signal_presets.add()
+        p.name = "Empty"
+        p.data = "[]"
     ui.register()
 
 
 def unregister():
     ui.unregister()
+    ui.unregister_props()
     operators.unregister()
     signals.unregister()
     tunnelfx.unregister()

--- a/operators.py
+++ b/operators.py
@@ -277,6 +277,8 @@ class VJLOOPER_OT_remove_preset(Operator):
     def execute(self, ctx):
         sc = ctx.scene
         sc.signal_presets.remove(sc.signal_preset_index)
+        idx = sc.signal_preset_index
+        sc.signal_preset_index = min(idx, len(sc.signal_presets) - 1)
         return {'FINISHED'}
 
 

--- a/tests/quick_register.py
+++ b/tests/quick_register.py
@@ -1,0 +1,6 @@
+import vjlooper
+
+# Register and unregister addon in a clean session
+vjlooper.register()
+vjlooper.unregister()
+print("VjLooper registered and unregistered without errors")


### PR DESCRIPTION
## Summary
- register custom properties before UI classes
- ensure presets list contains a dummy entry when empty
- keep preset index valid after deleting presets
- guard preset UI against missing list
- add manual test script for registering the addon

## Testing
- `pytest -q`
- `blender --background --python tests/quick_register.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68579da79278832eb3002740e01432f8