### PR TITLE
Fix translation re-registration error

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -60,7 +60,11 @@ if not os.environ.get("VJ_TESTING"):
 
 
 def register():
-    bpy.app.translations.register(__package__, translation_dict)
+    try:
+        bpy.app.translations.register(__package__, translation_dict)
+    except ValueError:
+        bpy.app.translations.unregister(__package__)
+        bpy.app.translations.register(__package__, translation_dict)
     signals.register()
     operators.register()
     tunnelfx.register()


### PR DESCRIPTION
## Summary
- prevent `bpy.app.translations.register` from raising `ValueError` when the addon is reloaded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a13aab20832ea2dbe7b4e765a15f