### PR TITLE
Fix registration order

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -60,30 +60,32 @@ if not os.environ.get("VJ_TESTING"):
 
 
 def register():
+    ui.register_props()
+    if not bpy.context.scene.signal_presets:
+        p = bpy.context.scene.signal_presets.add()
+        p.name = "Empty"
+        p.data = "[]"
+    operators.register()
+    tunnelfx.register()
+    ui.register()
     try:
         bpy.app.translations.register(__package__, translation_dict)
     except ValueError:
         bpy.app.translations.unregister(__package__)
         bpy.app.translations.register(__package__, translation_dict)
     signals.register()
-    operators.register()
-    tunnelfx.register()
-    ui.register_props()
-    # ensure collections exist before UI classes are registered
-    if not bpy.context.scene.signal_presets:
-        p = bpy.context.scene.signal_presets.add()
-        p.name = "Empty"
-        p.data = "[]"
-    ui.register()
 
 
 def unregister():
-    ui.unregister()
-    ui.unregister_props()
-    operators.unregister()
     signals.unregister()
+    try:
+        bpy.app.translations.unregister(__package__)
+    except KeyError:
+        pass
+    ui.unregister()
     tunnelfx.unregister()
-    bpy.app.translations.unregister(__package__)
+    operators.unregister()
+    ui.unregister_props()
 
 
 if __name__ == "__main__":

--- a/ui.py
+++ b/ui.py
@@ -443,11 +443,6 @@ def register_props():
     sc.vj_only_used = BoolProperty(name="Only used", default=False)
     sc.vj_filtered_materials = CollectionProperty(type=VJMaterialItem)
 
-    if not bpy.context.scene.signal_presets:
-        p = bpy.context.scene.signal_presets.add()
-        p.name = "Empty"
-        p.data = "[]"
-
 
 def unregister_props():
     """Remove custom properties from Blender data-blocks."""


### PR DESCRIPTION
## Summary
- move `ui.register_props()` to the start of `register()`
- register classes before translations and call `signals.register()` last
- add translation unregister guard
- remove duplicate default preset initialization from `register_props`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a529843c832e9d1b08ead24f7cc3