### PR TITLE
Fix preferences lookup on registration

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -520,8 +520,8 @@ class VJLOOPER_OT_random_hue_shift(Operator):
     def execute(self, ctx):
         import colorsys
         sc = ctx.scene
-        prefs = ctx.preferences.addons[__package__].preferences
-        rng = self.range if self.range > 0 else prefs.hue_shift_range
+        prefs = signals._prefs()
+        rng = self.range if self.range > 0 else (prefs.hue_shift_range if prefs else 0.0)
         mats = signals.get_materials_list(sc)
         idx = sc.vj_material_index
         if idx >= len(mats):

--- a/ui.py
+++ b/ui.py
@@ -343,8 +343,8 @@ addon_keymaps = []
 
 
 def register_keymaps():
-    prefs = bpy.context.preferences.addons[__package__].preferences
-    if not prefs.use_keymaps:
+    prefs = signals._prefs()
+    if not prefs or not prefs.use_keymaps:
         return
     wm = bpy.context.window_manager
     kc = wm.keyconfigs.addon


### PR DESCRIPTION
## Summary
- add `_prefs()` helper to look up add-on preferences safely
- use `_prefs()` across modules
- guard preview setup and preset file retrieval when prefs are missing
- default to presets.json when prefs are unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a7e3c7b4832eb2902c4511921d0c