### PR TITLE
Fix preset loading when no scene context

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,6 +20,15 @@ if os.environ.get("VJ_TESTING"):
 else:
     import bpy
 
+
+def _scene():
+    """Return the current scene or fallback to first available scene."""
+    if hasattr(bpy.context, "scene") and bpy.context.scene:
+        return bpy.context.scene
+    if bpy.data.scenes:
+        return bpy.data.scenes[0]
+    return None
+
 if bpy.app.version < (3, 6, 0):
     bl_info["warning"] = "Limited support for Blender versions before 3.6"
 else:
@@ -62,8 +71,9 @@ if not os.environ.get("VJ_TESTING"):
 
 def register():
     ui.register_props()
-    if not bpy.context.scene.signal_presets:
-        p = bpy.context.scene.signal_presets.add()
+    sc = _scene()
+    if sc and not sc.signal_presets:
+        p = sc.signal_presets.add()
         p.name = "Empty"
         p.data = "[]"
     operators.register()


### PR DESCRIPTION
## Summary
- avoid accessing bpy.context.scene when no scene is available
- provide fallback scene accessor
- load/save presets only when a scene exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ae33a7b4832e944489bb4477ea7e