### PR TITLE
Fix _scene helpers when bpy.data is restricted

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,11 +22,13 @@ else:
 
 
 def _scene():
-    """Return the current scene or fallback to first available scene."""
-    if hasattr(bpy.context, "scene") and bpy.context.scene:
-        return bpy.context.scene
-    if bpy.data.scenes:
-        return bpy.data.scenes[0]
+    """Return the current scene or first available scene if accessible."""
+    ctx = getattr(bpy, "context", None)
+    if ctx and getattr(ctx, "scene", None):
+        return ctx.scene
+    data = getattr(bpy, "data", None)
+    if data and hasattr(data, "scenes") and data.scenes:
+        return data.scenes[0]
     return None
 
 if bpy.app.version < (3, 6, 0):

--- a/signals.py
+++ b/signals.py
@@ -13,11 +13,13 @@ from .core import persistence as core_persistence
 
 
 def _scene():
-    """Return the current scene or fallback to first available scene."""
-    if hasattr(bpy.context, "scene") and bpy.context.scene:
-        return bpy.context.scene
-    if bpy.data.scenes:
-        return bpy.data.scenes[0]
+    """Return the current scene or first available scene if accessible."""
+    ctx = getattr(bpy, "context", None)
+    if ctx and getattr(ctx, "scene", None):
+        return ctx.scene
+    data = getattr(bpy, "data", None)
+    if data and hasattr(data, "scenes") and data.scenes:
+        return data.scenes[0]
     return None
 
 


### PR DESCRIPTION
## Summary
- add defensive checks for `bpy.context.scene` and `bpy.data.scenes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857af2f8824832e9e6c00cd7112359d