### PR TITLE
Improve operator re-registration

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -613,14 +613,19 @@ def register():
         try:
             bpy.utils.register_class(c)
         except ValueError:
-            # Allow re-registration if Blender left classes registered
-            bpy.utils.unregister_class(c)
+            # Class may be left registered from a previous version
+            existing = getattr(bpy.types, c.__name__, None)
+            if existing:
+                bpy.utils.unregister_class(existing)
             bpy.utils.register_class(c)
 
 
 def unregister():
     for c in reversed(classes):
+        existing = getattr(bpy.types, c.__name__, None)
+        if not existing:
+            continue
         try:
-            bpy.utils.unregister_class(c)
+            bpy.utils.unregister_class(existing)
         except RuntimeError:
             pass


### PR DESCRIPTION
## Summary
- clean up old operator classes before registering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b1348964832eb86149507f672ac7