### PR TITLE
Improve registration reliability

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,55 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 sys.path.insert(0, ROOT)
 
 bpy_stub = types.ModuleType('bpy')
-bpy_stub.app = types.SimpleNamespace(version=(3, 6, 0))
+bpy_stub.app = types.SimpleNamespace(
+    version=(3, 6, 0),
+    translations=types.SimpleNamespace(register=lambda *a, **k: None, unregister=lambda *a, **k: None),
+    handlers=types.SimpleNamespace(frame_change_pre=[], depsgraph_update_post=[]),
+)
+context_stub = types.SimpleNamespace(
+    preferences=types.SimpleNamespace(addons={}),
+    window_manager=types.SimpleNamespace(keyconfigs=types.SimpleNamespace(addon=None)),
+    region=None,
+    region_data=None,
+    scene=None,
+    view_layer=types.SimpleNamespace(objects=types.SimpleNamespace(active=None)),
+    selected_objects=[],
+)
+bpy_stub.context = context_stub
+bpy_stub.data = types.SimpleNamespace(scenes=[])
+utils_stub = types.SimpleNamespace(register_class=lambda *a, **k: None, unregister_class=lambda *a, **k: None)
+bpy_stub.utils = utils_stub
+types_mod = types.SimpleNamespace(
+    Object=type('Object', (), {}),
+    Scene=type('Scene', (), {}),
+    Material=type('Material', (), {}),
+    Collection=type('Collection', (), {}),
+    Operator=type('Operator', (), {}),
+    Panel=type('Panel', (), {}),
+    UIList=type('UIList', (), {}),
+    AddonPreferences=type('AddonPreferences', (), {}),
+    PropertyGroup=type('PropertyGroup', (), {}),
+    SpaceView3D=type('SpaceView3D', (), {
+        'draw_handler_add': lambda *a, **k: None,
+        'draw_handler_remove': lambda *a, **k: None,
+    }),
+)
+bpy_stub.types = types_mod
+sys.modules.setdefault('bpy.types', types_mod)
+props_mod = types.ModuleType('bpy.props')
+for name in ['BoolProperty', 'EnumProperty', 'FloatProperty', 'FloatVectorProperty',
+             'IntProperty', 'PointerProperty', 'StringProperty', 'CollectionProperty']:
+    setattr(props_mod, name, lambda *a, **k: None)
+bpy_stub.props = props_mod
 sys.modules.setdefault('bpy', bpy_stub)
+sys.modules.setdefault('bpy.props', props_mod)
 mathutils_stub = types.ModuleType('mathutils')
 mathutils_stub.Vector = lambda *a, **kw: None
 sys.modules.setdefault('mathutils', mathutils_stub)
 bx = types.ModuleType('bpy_extras')
 bx.view3d_utils = types.SimpleNamespace(location_3d_to_region_2d=lambda *a, **k: None)
+bx.io_utils = types.SimpleNamespace(ExportHelper=object, ImportHelper=object)
 sys.modules.setdefault('bpy_extras', bx)
+sys.modules.setdefault('bpy_extras.view3d_utils', bx.view3d_utils)
+sys.modules.setdefault('bpy_extras.io_utils', bx.io_utils)
+sys.modules.setdefault('blf', types.ModuleType('blf'))

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,40 @@
+import importlib
+import os
+import sys
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+sys.path.insert(0, ROOT)
+
+import vjlooper
+
+
+def test_modules_imported():
+    assert hasattr(vjlooper, "ui")
+    assert hasattr(vjlooper, "operators")
+
+
+def test_register_rollback(monkeypatch):
+    called = {}
+
+    def fail_register():
+        called["fail"] = True
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(vjlooper.operators, "register", fail_register)
+    with pytest.raises(RuntimeError):
+        vjlooper.register()
+
+    # replace with no-op for successful registration
+    monkeypatch.setattr(vjlooper.operators, "register", lambda: called.setdefault("ok", True))
+    monkeypatch.setattr(vjlooper.tunnelfx, "register", lambda: None)
+    monkeypatch.setattr(vjlooper.tunnelfx, "unregister", lambda: None)
+    vjlooper.register()
+    vjlooper.unregister()
+
+
+def test_unregister_props_no_error():
+    # ensure calling without prior registration doesn't raise
+    importlib.reload(vjlooper.ui)
+    vjlooper.ui.unregister_props()
+

--- a/ui.py
+++ b/ui.py
@@ -544,10 +544,14 @@ def register_props():
 
 def unregister_props():
     """Remove custom properties from Blender data-blocks."""
-    del bpy.types.Object.signal_items
-    del bpy.types.Object.global_amp_scale
-    del bpy.types.Object.global_freq_scale
-    del bpy.types.Object.global_dur_scale
+    if hasattr(bpy.types.Object, "signal_items"):
+        del bpy.types.Object.signal_items
+    if hasattr(bpy.types.Object, "global_amp_scale"):
+        del bpy.types.Object.global_amp_scale
+    if hasattr(bpy.types.Object, "global_freq_scale"):
+        del bpy.types.Object.global_freq_scale
+    if hasattr(bpy.types.Object, "global_dur_scale"):
+        del bpy.types.Object.global_dur_scale
 
     for prop in [
         "signal_new_channel", "signal_new_type", "signal_new_amplitude",
@@ -563,7 +567,8 @@ def unregister_props():
         "bake_start", "bake_end", "bake_channel",
         "vj_material_index", "vj_target_collection", "vj_only_used", "vj_filtered_materials",
     ]:
-        delattr(bpy.types.Scene, prop)
+        if hasattr(bpy.types.Scene, prop):
+            delattr(bpy.types.Scene, prop)
     for c in reversed(property_classes):
         bpy.utils.unregister_class(c)
 


### PR DESCRIPTION
## Summary
- always import addon modules even during tests
- roll back addon registration on failure
- make `unregister_props` safe if attributes are missing
- expand test stubs for Blender modules
- add tests for registration rollback and unregister resilience

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596e9994b8832ea624e386787f0c76