### PR TITLE
Ensure safe re-registration of properties

### DIFF
--- a/tests/double_register.py
+++ b/tests/double_register.py
@@ -1,8 +1,0 @@
-import vjlooper
-
-# Register/unregister twice to ensure idempotency
-vjlooper.register()
-vjlooper.unregister()
-vjlooper.register()
-vjlooper.unregister()
-print("Registered twice without errors")

--- a/tests/test_double_register.py
+++ b/tests/test_double_register.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+sys.path.insert(0, ROOT)
+
+import vjlooper
+
+
+def test_double_register(monkeypatch):
+    """Registering multiple times should never raise ValueError."""
+    monkeypatch.setattr(vjlooper.tunnelfx, "register", lambda: None)
+    monkeypatch.setattr(vjlooper.tunnelfx, "unregister", lambda: None)
+
+    vjlooper.register()
+    vjlooper.unregister()
+    vjlooper.register()
+    vjlooper.unregister()
+
+
+

--- a/ui.py
+++ b/ui.py
@@ -382,13 +382,10 @@ classes = (
 def register_props():
     """Register custom properties for Object and Scene types."""
     for c in property_classes:
-        try:
-            bpy.utils.register_class(c)
-        except ValueError:
-            existing = getattr(bpy.types, c.__name__, None)
-            if existing:
-                bpy.utils.unregister_class(existing)
-            bpy.utils.register_class(c)
+        existing = getattr(bpy.types, c.__name__, None)
+        if existing:
+            bpy.utils.unregister_class(existing)
+        bpy.utils.register_class(c)
 
     if hasattr(bpy.types.Object, "signal_items"):
         del bpy.types.Object.signal_items
@@ -570,7 +567,12 @@ def unregister_props():
         if hasattr(bpy.types.Scene, prop):
             delattr(bpy.types.Scene, prop)
     for c in reversed(property_classes):
-        bpy.utils.unregister_class(c)
+        existing = getattr(bpy.types, c.__name__, None)
+        if existing:
+            try:
+                bpy.utils.unregister_class(existing)
+            except Exception:
+                pass
 
 
 def register():


### PR DESCRIPTION
## Summary
- safely unregister property classes before registering them
- ignore missing classes when unregistering
- convert double register script into a pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597cebe4f0832eb8a751155e37f035