### PR TITLE
Fix default preset loading

### DIFF
--- a/signals.py
+++ b/signals.py
@@ -312,6 +312,11 @@ def load_presets_from_disk():
         return
     path = Path(get_preset_file())
     presets = core_persistence.load_presets(path)
+    if not presets:
+        fallback = Path(os.path.join(os.path.dirname(__file__), "example_presets.json"))
+        if fallback.exists():
+            with open(fallback) as f:
+                presets = json.load(f)
     if presets:
         sc.signal_presets.clear()
         for e in presets:

--- a/tests/test_default_presets.py
+++ b/tests/test_default_presets.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+sys.path.insert(0, ROOT)
+
+import vjlooper.signals as signals
+
+class Item:
+    pass
+
+class PresetCollection(list):
+    def add(self):
+        it = Item()
+        self.append(it)
+        return it
+    def clear(self):
+        super().clear()
+
+def test_load_default_presets(tmp_path, monkeypatch):
+    scene = types.SimpleNamespace(signal_presets=PresetCollection())
+    monkeypatch.setattr(signals, "_scene", lambda: scene)
+    monkeypatch.setattr(signals, "get_preset_file", lambda: tmp_path / "presets.json")
+    signals.load_presets_from_disk()
+    assert len(scene.signal_presets) > 0


### PR DESCRIPTION
## Summary
- load example presets when saved presets file doesn't exist
- test that default presets are loaded if no file is present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68600e9947d0832e865bf6020591d4d9