### PR TITLE
Fix smoothing cache persistence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -8,7 +8,7 @@ from core import signals as core_signals
 
 
 def test_sine_wave():
-    params = core_signals.SignalParams(signal_type='SINE', duration=10)
+    params = core_signals.SignalParams(signal_type="SINE", duration=10)
     # start frame should return base value
     assert core_signals.calc_signal(params, 0) == 0.0
     # value at frame 2 for duration 10
@@ -17,14 +17,14 @@ def test_sine_wave():
 
 
 def test_sine_loop():
-    params = core_signals.SignalParams(signal_type='SINE', duration=24, frequency=1)
+    params = core_signals.SignalParams(signal_type="SINE", duration=24, frequency=1)
     val0 = core_signals.calc_signal(params, 0)
     val24 = core_signals.calc_signal(params, 24)
     assert math.isclose(val0, val24, abs_tol=1e-6)
 
 
 def test_triangle_wave():
-    params = core_signals.SignalParams(signal_type='TRIANGLE', duration=4)
+    params = core_signals.SignalParams(signal_type="TRIANGLE", duration=4)
     val0 = core_signals.calc_signal(params, 0)
     val2 = core_signals.calc_signal(params, 2)
     assert math.isclose(val0, -1.0, abs_tol=1e-4)
@@ -32,7 +32,7 @@ def test_triangle_wave():
 
 
 def test_loop_lock_quantization():
-    params = core_signals.SignalParams(signal_type='SINE', duration=8, frequency=1.3)
+    params = core_signals.SignalParams(signal_type="SINE", duration=8, frequency=1.3)
     val_unlocked = core_signals.calc_signal(params, 4, loop_lock=False)
     val_locked = core_signals.calc_signal(params, 4, loop_lock=True)
     # frequencies differ when loop lock active
@@ -40,8 +40,26 @@ def test_loop_lock_quantization():
 
 
 def test_loop_lock():
-    params = core_signals.SignalParams(signal_type='SINE', duration=24, frequency=1.3)
+    params = core_signals.SignalParams(signal_type="SINE", duration=24, frequency=1.3)
     locked = core_signals.calc_signal(params, 5, loop_lock=True)
     qfreq = round(params.frequency * params.duration) / params.duration
-    expected = core_signals.calc_signal(core_signals.SignalParams(signal_type='SINE', duration=24, frequency=qfreq), 5)
+    expected = core_signals.calc_signal(
+        core_signals.SignalParams(signal_type="SINE", duration=24, frequency=qfreq), 5
+    )
     assert math.isclose(locked, expected, abs_tol=1e-6)
+
+
+def test_smoothing_persistent():
+    core_signals.smoothing_cache.clear()
+    raw0 = core_signals.calc_signal(
+        core_signals.SignalParams(signal_type="SINE", duration=10), 0
+    )
+    raw1 = core_signals.calc_signal(
+        core_signals.SignalParams(signal_type="SINE", duration=10), 1
+    )
+    core_signals.smoothing_cache.clear()
+    params = core_signals.SignalParams(signal_type="SINE", duration=10, smoothing=0.5)
+    smooth0 = core_signals.calc_signal(params, 0, cache_key="x")
+    smooth1 = core_signals.calc_signal(params, 1, cache_key="x")
+    assert math.isclose(raw0, smooth0, abs_tol=1e-6)
+    assert not math.isclose(raw1, smooth1, abs_tol=1e-6)


### PR DESCRIPTION
## Summary
- remove unused `SignalCache`
- let `core.calc_signal` accept a `cache_key` to persist smoothing
- use object and item names as cache key when evaluating signals
- add tests for smoothing persistence
- add MIT license

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860172aea44832ea34d975f0cecb461