### PR TITLE
Fix load_group AttributeError

### DIFF
--- a/tunnelfx.py
+++ b/tunnelfx.py
@@ -9,7 +9,14 @@ _PATH = Path(__file__).parent / "assets" / "gn" / "TunnelFX_CYL.blend"
 
 def load_group():
     """Load and return the geometry node group for the tunnel effect."""
-    node_groups = getattr(getattr(bpy, "data", None), "node_groups", None)
+    data = getattr(bpy, "data", None)
+    node_groups = None
+    if data is not None:
+        try:
+            node_groups = data.node_groups
+        except AttributeError:
+            # running in restricted context
+            node_groups = None
     if node_groups is None:
         return None
     if _GROUP in node_groups:


### PR DESCRIPTION
## Summary
- handle restricted `bpy.data` access in `tunnelfx.load_group`
- keep defensive unregister

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d9a83fcc832e8e883f96329ba505